### PR TITLE
Adds round-tripped Jupytext generated ipynb (ipynb->Rmd->ipynb)

### DIFF
--- a/jupyter/Figure1cYarnVersion.ipynb
+++ b/jupyter/Figure1cYarnVersion.ipynb
@@ -703,14 +703,6 @@
    "display_name": "R",
    "language": "R",
    "name": "ir"
-  },
-  "language_info": {
-   "codemirror_mode": "r",
-   "file_extension": ".r",
-   "mimetype": "text/x-r-source",
-   "name": "R",
-   "pygments_lexer": "r",
-   "version": "3.6.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# ⚠️ This PR is NOT to be merged. 

I created to check the `diff` and be mindful of the fidelity of a cross trip conversion of an `.ipynb` R kernel notebook, generated in Jupyter Lab via GUI with `+` in our custom conda env (see `dependencies/README.md`). 

>  *a cross trip conversion*

**ipynb --(jupytext=1.3.3)-->Rmd--(jupytext=1.3.3)-->ipynb**

Commented in an issue and awaiting feedback from the developer https://github.com/mwouts/jupytext/issues/426#issuecomment-589060163