### PR TITLE
Adds template .ipynb

### DIFF
--- a/templates/template.ipynb
+++ b/templates/template.ipynb
@@ -1,0 +1,177 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Figure xx - `{Figure legend }`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A small description for the analysis, the metrics and how to interpret the figure."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **NOTE**:\n",
+    "\n",
+    "We assume that you have cloned the analysis repository and have `cd` into the parent directory. Before starting with the analysis make sure you have first completed the dependencies set up by following the instructions described in the **`dependencies/README.md`** document. All paths defined in this Notebook are relative to the parent directory (repository). Please close this Notebook and start again by following the above guidelines if you have not completed the aforementioned steps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "library(...)\n",
+    "library(...)\n",
+    "Sys.setenv(TAR = \"/bin/tar\") # for gzfile"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## ## Use double hash for header 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Some text for describing what is going to be executed and what it will produce"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "'/mnt/shared/ec2-user/session_data/sbas/templates'"
+      ],
+      "text/latex": [
+       "'/mnt/shared/ec2-user/session\\_data/sbas/templates'"
+      ],
+      "text/markdown": [
+       "'/mnt/shared/ec2-user/session_data/sbas/templates'"
+      ],
+      "text/plain": [
+       "[1] \"/mnt/shared/ec2-user/session_data/sbas/templates\""
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# a code block\n",
+    "getwd()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## ... \n",
+    "more of the above sequence"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Metadata\n",
+    "\n",
+    "For replicability and reproducibility purposes, we also print the following metadata:\n",
+    "\n",
+    "1. Checksums of **'artefacts'**, files generated during the analysis and stored in the folder directory **`data`**\n",
+    "2. List of environment metadata, dependencies, versions of libraries using `utils::sessionInfo()` and [`devtools::session_info()`](https://devtools.r-lib.org/reference/session_info.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Checksums with the sha256 algorithm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "figure_id   = \"<the-figure-i-am-working-on>\"\n",
+    "\n",
+    "message(\"Generating sha256 checksums of the artefacts in the `..data/` directory .. \")\n",
+    "system(paste0(\"cd ../data/ && sha256sum * > ../metadata/\", figure_id, \"_sha256sums.txt\"), intern = TRUE)\n",
+    "message(\"Done!\\n\")\n",
+    "\n",
+    "data.table::fread(paste0(\"../metadata/\", figure_id, \"_sha256sums.txt\"), header = FALSE, col.names = c(\"sha256sum\", \"file\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2. Libraries metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "figure_id   = \"<the-figure-i-am-working-on>\"\n",
+    "\n",
+    "dev_session_info   <- devtools::session_info()\n",
+    "utils_session_info <- utils::sessionInfo()\n",
+    "\n",
+    "message(\"Saving `devtools::session_info()` objects in ../metadata/devtools_session_info.rds  ..\")\n",
+    "saveRDS(dev_session_info, file = paste0(\"../metadata/\", figure_id, \"_devtools_session_info.rds\"))\n",
+    "message(\"Done!\\n\")\n",
+    "\n",
+    "message(\"Saving `utils::sessionInfo()` objects in ../metadata/utils_session_info.rds  ..\")\n",
+    "saveRDS(utils_session_info, file = paste0(\"../metadata/\", figure_id ,\"_utils_info.rds\"))\n",
+    "message(\"Done!\\n\")\n",
+    "\n",
+    "session_info$platform\n",
+    "session_info$packages[session_info$packages$attached==TRUE, ]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "R",
+   "language": "R",
+   "name": "ir"
+  },
+  "language_info": {
+   "codemirror_mode": "r",
+   "file_extension": ".r",
+   "mimetype": "text/x-r-source",
+   "name": "R",
+   "pygments_lexer": "r",
+   "version": "3.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR adds a directory named `templates` in the repo. The `template.ipynb` has some required cells of code that every notebook should have, to be sure we are capturing the dependencies and artefacts metadata. 

You can review how the notebook looks by previewing the `.ipynb` here:

https://github.com/TheJacksonLaboratory/sbas/blob/cristina-adds-templates/templates/template.ipynb

![image](https://user-images.githubusercontent.com/38183826/75258909-17fcfa00-57df-11ea-9a43-ff3fa053b33a.png)

