### PR TITLE
Adds README.md in the data folder

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,3 @@
+## The folder `data`
+
+We use the folder **`data`** to store the artefacts that are generated during the analysis, so this folder should appear empty on GitHub. Large files cannot be pushed to GitHub as done with code. One different approach we can adopt for tracking medium sized artefacts up to 2GB. For this purpose we utilise the R package [`ropensci/piggyback`](https://github.com/ropensci/piggyback). This is still a work in progress and we will only sustain this for developing for as long as parts of this projects are a work in progress. See the following section about utilising cached intermediate files for more details.


### PR DESCRIPTION
This PR adds a README.md in the data folder. This serves 2 purposes.

### - We are reminded of the use of the directory .
The `data/` folder stays empty in GitHub and we use it only as an ephemeral vessel to hold the files fetched during runtime or generated as either intermediate files or final artefacts of the analysis.

### - It acts as a file-placeholder for retaining the folder.
If the folder is empty it cannot be commited.