### PR TITLE
Adds post-rMATS notebook (SRA ids intersect)

### DIFF
--- a/Rmd/keep_intersect.Rmd
+++ b/Rmd/keep_intersect.Rmd
@@ -29,17 +29,55 @@ library(R.utils) # required for data.table's gzip util
 rmats_matrices_suffix <- "*.txt.gz"
 ```
 
-## 1. Decompress the `rmats_final.tar.gz` 
-[CloudOS link](https://cloudos.lifebit.ai/app/jobs/5e83b03ee7d1990104ccacd4) for the job merging all individual samples matrices into 50 rMATS final matrices
+<!-- #region -->
+## 1. Access and decompress the `rmats_final.tar.gz` 
+The successfully completed Nextflow analysis, that has combined all individual samples matrices into 50 rMATS final matrices utilises the [create_matrices_from_files.sh](https://github.com/lifebit-ai/rmats-nf/blob/master/containers/post-rmats/create_matrices_from_files.sh). This analysis has generated a single archive file named `rmats_final.tar.gz` that contains all the 50 summarised matrices, in `.txt.gz` format.
+
+We can access the `rmats_final.tar.gz` from the respective google project bucket in the location:
+
+<img src="https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/google_cloud_logo.png" width="30"/>   **`  gs://robinson-bucket/results/merged_matrices/rmats_final.tar.gz`**
+
+On CloudOS, we can link the data from the bucket in the Jupyter Notebook session. For example, if we would like to access the data from a successfully completed Nextflow job, in this example the `rmats_final.tar.gz`, we can follow the steps below:
+
+|STEP|DESCRIPTION|
+|:---|:---|
+|1. | Go to the **Analysis Job page** of the pipeline with the results of interest <a href="https://cloudos.lifebit.ai/app/jobs/5e83b03ee7d1990104ccacd4" target="_blank"><img src="https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/cloudos_badge.png" width="80"/></a> |c
+|2. | Click on the  <img src="https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/cloudos_results.png" width="65"/> tab and copy the results folder name from  <kbd>rMATS-batches > **merge-rmats-5e83b03ee7d1990104ccacd4** </kbd> (project > results folder) |
+| 3.| <img src="https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/cloudos_jupyter_grey_icon.png" width="25"/>  Navigate to the Jupyter Notebook Session in CloudOS |
+| 4.| Create a new Jupyter Notebook Session by clicking <img src="https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/cloudos_new_jupyter_session.png" width="55"/> ; it will take 1-2' until your sesssion is initialised |
+| 5. | Click on the blue arrow on the left of the screen <img src="https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/cloudos_jupyter_add_data.png" width="25"/> to expand the **`Session data`** <img src="https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/cloudos_add_dataset.png" width="25"/> interface |
+|5. |Once the `Data` interface pops up, click on **`Project results`** |
+|6. | Select the project associated with the Nextflow job, ie. `rMATS-batches`|
+|7. | For convenience, <kbd>**CTRL + F**</kbd> the folder results name you copied in <u>step 2</u> and select this folder |
+|8. | Navigate inside the results folder, select the `rmats_final.tar.gz` file and click the choose button <img src="https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/cloudos_data_choose.png" width="55"/>  to initiate the data mounting will initiate
+|9. |  Once the loader icon stops spinning your data are available to use <img src="https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/cloudos_jupyter_mounted_data_loaded.gif" width="185"/>  
+|10. | Your imported data will appear in the folder named `mounted_data/`. You can access the data: **i)** by clicking the JupyterLab parent folder icon on the top left of the screen <img src="https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/jupyter_lab_parent_folder.png " width="35"/> and navigating into the folders or **ii)** using the terminal `cd /mnt/shared/gcp-user/session_data/mounted_data/`
+
+
+**Here is an overview of all the steps described above:**
+---
+
+![](https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/access_data.gif)
+
+<!-- #endregion -->
+
+> **NOTE**: To work with shorter filepaths, we can move the `rmats_final.tar.gz` file in the `data` folder, which we use as a vessel for all input files during the analysis. 
 
 ```{r}
-system("tar -xvzf rmats_final.tar.gz", intern = TRUE)
+longpath <-  "../../mounted-data/cloudosinputdata/deploit/teams/5e601f9f786cca0107921955/users/5c066455e0744f007585e826/projects/5e820cb0bc45f60104372e9a/jobs/5e83b03ee7d1990104ccacd4/results/results/archive/rmats_final.tar.gz"
+system(paste0("mv ", longpath, " ../data/"), intern = TRUE)
+```
+
+We proceed to decompress the archive to access the 50 matrices:
+
+```{r}
+system("tar -xvzf ../data/rmats_final.tar.gz", intern = TRUE)
 ```
 
 ## 2. Delete the `*txt.filelist.txt` files that are not required
 
 ```{r}
-system("rm -f *txt.filelist.txt", intern = TRUE)
+system("rm -f ../data/*txt.filelist.txt", intern = TRUE)
 ```
 
 <!-- #region -->

--- a/jupyter/keep_intersect.ipynb
+++ b/jupyter/keep_intersect.ipynb
@@ -44,8 +44,41 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1. Decompress the `rmats_final.tar.gz` \n",
-    "[CloudOS link](https://cloudos.lifebit.ai/app/jobs/5e83b03ee7d1990104ccacd4) for the job merging all individual samples matrices into 50 rMATS final matrices"
+    "## 1. Access and decompress the `rmats_final.tar.gz` \n",
+    "The successfully completed Nextflow analysis, that has combined all individual samples matrices into 50 rMATS final matrices utilises the [create_matrices_from_files.sh](https://github.com/lifebit-ai/rmats-nf/blob/master/containers/post-rmats/create_matrices_from_files.sh). This analysis has generated a single archive file named `rmats_final.tar.gz` that contains all the 50 summarised matrices, in `.txt.gz` format.\n",
+    "\n",
+    "We can access the `rmats_final.tar.gz` from the respective google project bucket in the location:\n",
+    "\n",
+    "<img src=\"https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/google_cloud_logo.png\" width=\"30\"/>   **`  gs://robinson-bucket/results/merged_matrices/rmats_final.tar.gz`**\n",
+    "\n",
+    "On CloudOS, we can link the data from the bucket in the Jupyter Notebook session. For example, if we would like to access the data from a successfully completed Nextflow job, in this example the `rmats_final.tar.gz`, we can follow the steps below:\n",
+    "\n",
+    "|STEP|DESCRIPTION|\n",
+    "|:---|:---|\n",
+    "|1. | Go to the **Analysis Job page** of the pipeline with the results of interest <a href=\"https://cloudos.lifebit.ai/app/jobs/5e83b03ee7d1990104ccacd4\" target=\"_blank\"><img src=\"https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/cloudos_badge.png\" width=\"80\"/></a> |c\n",
+    "|2. | Click on the  <img src=\"https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/cloudos_results.png\" width=\"65\"/> tab and copy the results folder name from  <kbd>rMATS-batches > **merge-rmats-5e83b03ee7d1990104ccacd4** </kbd> (project > results folder) |\n",
+    "| 3.| <img src=\"https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/cloudos_jupyter_grey_icon.png\" width=\"25\"/>  Navigate to the Jupyter Notebook Session in CloudOS |\n",
+    "| 4.| Create a new Jupyter Notebook Session by clicking <img src=\"https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/cloudos_new_jupyter_session.png\" width=\"55\"/> ; it will take 1-2' until your sesssion is initialised |\n",
+    "| 5. | Click on the blue arrow on the left of the screen <img src=\"https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/cloudos_jupyter_add_data.png\" width=\"25\"/> to expand the **`Session data`** <img src=\"https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/cloudos_add_dataset.png\" width=\"25\"/> interface |\n",
+    "|5. |Once the `Data` interface pops up, click on **`Project results`** |\n",
+    "|6. | Select the project associated with the Nextflow job, ie. `rMATS-batches`|\n",
+    "|7. | For convenience, <kbd>**CTRL + F**</kbd> the folder results name you copied in <u>step 2</u> and select this folder |\n",
+    "|8. | Navigate inside the results folder, select the `rmats_final.tar.gz` file and click the choose button <img src=\"https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/cloudos_data_choose.png\" width=\"55\"/>  to initiate the data mounting will initiate\n",
+    "|9. |  Once the loader icon stops spinning your data are available to use <img src=\"https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/cloudos_jupyter_mounted_data_loaded.gif\" width=\"185\"/>  \n",
+    "|10. | Your imported data will appear in the folder named `mounted_data/`. You can access the data: **i)** by clicking the JupyterLab parent folder icon on the top left of the screen <img src=\"https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/jupyter_lab_parent_folder.png \" width=\"35\"/> and navigating into the folders or **ii)** using the terminal `cd /mnt/shared/gcp-user/session_data/mounted_data/`\n",
+    "\n",
+    "\n",
+    "**Here is an overview of all the steps described above:**\n",
+    "---\n",
+    "\n",
+    "![](https://github.com/TheJacksonLaboratory/sbas/raw/master/assets/access_data.gif)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **NOTE**: To work with shorter filepaths, we can move the `rmats_final.tar.gz` file in the `data` folder, which we use as a vessel for all input files during the analysis. "
    ]
   },
   {
@@ -54,7 +87,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "system(\"tar -xvzf rmats_final.tar.gz\", intern = TRUE)"
+    "longpath <-  \"../../mounted-data/cloudosinputdata/deploit/teams/5e601f9f786cca0107921955/users/5c066455e0744f007585e826/projects/5e820cb0bc45f60104372e9a/jobs/5e83b03ee7d1990104ccacd4/results/results/archive/rmats_final.tar.gz\"\n",
+    "system(paste0(\"mv \", longpath, \" ../data/\"), intern = TRUE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We proceed to decompress the archive to access the 50 matrices:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system(\"tar -xvzf ../data/rmats_final.tar.gz\", intern = TRUE)"
    ]
   },
   {
@@ -70,7 +120,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "system(\"rm -f *txt.filelist.txt\", intern = TRUE)"
+    "system(\"rm -f ../data/*txt.filelist.txt\", intern = TRUE)"
    ]
   },
   {


### PR DESCRIPTION
**ℹ️  Pull Request (PR) Overview:**
---

This PR adds a notebook containing the code for the post-processing after the [create_matrices_from_files.sh](https://github.com/lifebit-ai/rmats-nf/blob/master/containers/post-rmats/create_matrices_from_files.sh) script has been run.

The purpose of this notebook is to 
- find the SRA ids shared amongst all 50 rMATS matrices produced by  [create_matrices_from_files.sh](https://github.com/lifebit-ai/rmats-nf/blob/master/containers/post-rmats/create_matrices_from_files.sh)
- for each of the 50 matrices, keep only the columns with the aforementioned ids

The notebook has been added in two formats:

- `.ipynb`: Jupyter Notebook
- `.Rmd` : Rmarkdown

The files are identical in content. The `.Rmd` was generated from the `.ipynb` using the [`jupytext` python library](https://github.com/mwouts/jupytext) with the following command:

```bash
# conda install jupytext
jupytext --update --to Rmd keep_intersect.ipynb
```



**🧐 Pull Request (PR) Review - How to:** 
--- 

<img src="https://user-images.githubusercontent.com/38183826/78364312-27791b00-75b5-11ea-9d06-bc7290a5a35c.png"  width="500"/></a>

On the top of the page here you can see that via this Pull Request **(PR)**, 
`cgpu` (Christina) wants to merge modifications of the repository made in the branch <kbd>cristina-post-rmats-ipynb</kbd> into the <kbd>master</kbd> branch.

To inspect the modifications made in in the branch for  Pull Requests **(PRs)** that contain jupyter notebooks the following steps are a good place to start:

**0. Access the files tab in this page**
<img src="https://user-images.githubusercontent.com/38183826/78364921-31e7e480-75b6-11ea-8efd-8d08c168ff37.png"  width="500"/></a>

**1. Inspect the `.Rmd` file as it is in plain text format**
<img src="https://user-images.githubusercontent.com/38183826/78365241-b63a6780-75b6-11ea-958c-f894ce8ff920.png"  width="500"/></a>

**2. Inspect the `.ipynb` format by clicking `view file`**
 <img src="http://g.recordit.co/AOydqrvrS7.gif"  width="500"/></a>

**📜 Background:**
---

 The [create_matrices_from_files.sh](https://github.com/lifebit-ai/rmats-nf/blob/master/containers/post-rmats/create_matrices_from_files.sh) combines the 50 rMATS matrices across individual SRA samples into collective matrices. All the final rMATS matrices contain one column named `ID` and as many columns as the SRA samples included in the analysis.

**🔗 Relevant Resources:**
---

1.  [create_matrices_from_files.sh](https://github.com/lifebit-ai/rmats-nf/blob/master/containers/post-rmats/create_matrices_from_files.sh) Nextflow implementation [here](https://github.com/lifebit-ai/merge-rmats-nf) 

2. CloudOS job for combining the matrices across all the samples [here*](https://cloudos.lifebit.ai/app/jobs/5e83b03ee7d1990104ccacd4)

___
\* You have to be logged in [CloudOS](https://cloudos.lifebit.ai/) and navigate into the `jaxT` workspace to be able to access the job from the link.