### PR TITLE
Adds FisherExactTests in reproduce.sh; Updates output

### DIFF
--- a/jupyter/FisherExactTests.ipynb
+++ b/jupyter/FisherExactTests.ipynb
@@ -2,7 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.010358,
+     "end_time": "2020-11-20T10:52:53.351537",
+     "exception": false,
+     "start_time": "2020-11-20T10:52:53.341179",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Analysis Notebook - Fisher exact test\n",
     "\n",
@@ -11,7 +20,16 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.009051,
+     "end_time": "2020-11-20T10:52:53.370206",
+     "exception": false,
+     "start_time": "2020-11-20T10:52:53.361155",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 1  Read in all and significant alternative splicing and differential gene expression results\n",
     "\n",
@@ -21,7 +39,22 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-11-20T10:52:53.475453Z",
+     "iopub.status.busy": "2020-11-20T10:52:53.472465Z",
+     "iopub.status.idle": "2020-11-20T10:53:30.109255Z",
+     "shell.execute_reply": "2020-11-20T10:53:30.108176Z"
+    },
+    "papermill": {
+     "duration": 36.73014,
+     "end_time": "2020-11-20T10:53:30.109483",
+     "exception": false,
+     "start_time": "2020-11-20T10:52:53.379343",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "results_dir  <- \"../data/\"\n",
@@ -37,9 +70,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 2,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-11-20T10:53:30.162461Z",
+     "iopub.status.busy": "2020-11-20T10:53:30.132876Z",
+     "iopub.status.idle": "2020-11-20T10:53:30.179821Z",
+     "shell.execute_reply": "2020-11-20T10:53:30.178728Z"
+    },
+    "papermill": {
+     "duration": 0.060634,
+     "end_time": "2020-11-20T10:53:30.179972",
+     "exception": false,
+     "start_time": "2020-11-20T10:53:30.119338",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       ".list-inline {list-style: none; margin:0; padding: 0}\n",
+       ".list-inline>li {display: inline-block}\n",
+       ".list-inline>li:not(:last-child)::after {content: \"\\00b7\"; padding: 0 .5ex}\n",
+       "</style>\n",
+       "<ol class=list-inline><li>'KDM6A'</li><li>'AL591686.1'</li></ol>\n"
+      ],
+      "text/latex": [
+       "\\begin{enumerate*}\n",
+       "\\item 'KDM6A'\n",
+       "\\item 'AL591686.1'\n",
+       "\\end{enumerate*}\n"
+      ],
+      "text/markdown": [
+       "1. 'KDM6A'\n",
+       "2. 'AL591686.1'\n",
+       "\n",
+       "\n"
+      ],
+      "text/plain": [
+       "[1] \"KDM6A\"      \"AL591686.1\""
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "show_n_lines_of_sets <- function(n_lines) {\n",
     "    head(sig_gene_as,n_lines)\n",
@@ -56,7 +134,16 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.009988,
+     "end_time": "2020-11-20T10:53:30.200099",
+     "exception": false,
+     "start_time": "2020-11-20T10:53:30.190111",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 2  Count up genes\n",
     "About 250 genes were found in the splicing data but not in the gene expression data, presumably related to the different processing pipelines used. We can therefore not make an assessment of whether these genes were differentially expressed or not, and thus we remove the genes prior to further analysis.\n"
@@ -64,18 +151,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
+   "execution_count": 3,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-11-20T10:53:30.225686Z",
+     "iopub.status.busy": "2020-11-20T10:53:30.224395Z",
+     "iopub.status.idle": "2020-11-20T10:53:35.110572Z",
+     "shell.execute_reply": "2020-11-20T10:53:35.109381Z"
+    },
+    "papermill": {
+     "duration": 4.900679,
+     "end_time": "2020-11-20T10:53:35.110764",
+     "exception": false,
+     "start_time": "2020-11-20T10:53:30.210085",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "All expression genes n=41705; all splicing genes n=14195; splicing genes not represented in expression set n=231\n",
-      "\n",
+      "All expression genes n=24053; all splicing genes n=12681; splicing genes not represented in expression set n=300\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
       "Note that we expect to find genes in the expression set that are not in the splicing set\n",
-      "\n",
-      "After removing the orphan splicing genes, we are left with  13964 genes in the splicing dataset\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "After removing the orphan splicing genes, we are left with  12381 genes in the splicing dataset\n",
       "\n"
      ]
     }
@@ -96,7 +210,16 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.011294,
+     "end_time": "2020-11-20T10:53:35.134294",
+     "exception": false,
+     "start_time": "2020-11-20T10:53:35.123000",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Create the sets of differentially expressed/spliced genes\n",
     "Note that we also need to correct the set of differentially spliced genes as above"
@@ -104,18 +227,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "execution_count": 4,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-11-20T10:53:35.161765Z",
+     "iopub.status.busy": "2020-11-20T10:53:35.160676Z",
+     "iopub.status.idle": "2020-11-20T10:53:35.205445Z",
+     "shell.execute_reply": "2020-11-20T10:53:35.204186Z"
+    },
+    "papermill": {
+     "duration": 0.059938,
+     "end_time": "2020-11-20T10:53:35.205611",
+     "exception": false,
+     "start_time": "2020-11-20T10:53:35.145673",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "total AS (uncorrected) n=2282; corrected n=2253\n",
-      "\n",
-      "significant differentially expresssed genes: n=3221/41705: 7.72329456899652%\n",
-      "\n",
-      "significant differentially spliced genes: n=2253/41705: 5.40222994844743%\n",
+      "total AS (uncorrected) n=888; corrected n=878\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "significant differentially expresssed genes: n=3221/24053: 13.3912609653681%\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "significant differentially spliced genes: n=878/24053: 3.6502723153037%\n",
       "\n"
      ]
     }
@@ -134,22 +284,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
+   "execution_count": 5,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-11-20T10:53:35.235727Z",
+     "iopub.status.busy": "2020-11-20T10:53:35.234476Z",
+     "iopub.status.idle": "2020-11-20T10:53:35.280000Z",
+     "shell.execute_reply": "2020-11-20T10:53:35.278755Z"
+    },
+    "papermill": {
+     "duration": 0.061877,
+     "end_time": "2020-11-20T10:53:35.280155",
+     "exception": false,
+     "start_time": "2020-11-20T10:53:35.218278",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Differentially expressed but not differentially spliced: n=2374/3221: 73.7038186898479% of all DGE genes\n",
-      "\n",
-      "Differentially spliced but not differentially spliced: n=1406/2253: 62.4056813138038% of all DAS genes\n",
-      "\n",
-      "DGE and DAS: 847; 2.03093154298046% of all genes\n",
-      "\n",
-      "By chance we would expect 174.005826639492, or 0.417230132213144%\n",
-      "\n",
-      "Number of genes with neither DGE nor DAS 37138\n",
+      "Differentially expressed but not differentially spliced: n=2963/3221: 91.9900651971437% of all DGE genes\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Differentially spliced but not differentially spliced: n=620/878: 70.6150341685649% of all DAS genes\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DGE and DAS: 258; 1.07263127260633% of all genes\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "By chance we would expect 117.575271275932, or 0.488817491688905%\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Number of genes with neither DGE nor DAS 20276\n",
       "\n"
      ]
     }
@@ -173,7 +362,16 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.014499,
+     "end_time": "2020-11-20T10:53:35.309470",
+     "exception": false,
+     "start_time": "2020-11-20T10:53:35.294971",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# 2.1 Check whether the increased proportion is statistically significant\n",
     "\n",
@@ -187,9 +385,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-11-20T10:53:35.343161Z",
+     "iopub.status.busy": "2020-11-20T10:53:35.342086Z",
+     "iopub.status.idle": "2020-11-20T10:53:35.398912Z",
+     "shell.execute_reply": "2020-11-20T10:53:35.397734Z"
+    },
+    "papermill": {
+     "duration": 0.075049,
+     "end_time": "2020-11-20T10:53:35.399073",
+     "exception": false,
+     "start_time": "2020-11-20T10:53:35.324024",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<caption>A matrix: 2 × 2 of type int</caption>\n",
+       "<tbody>\n",
+       "\t<tr><td> 258</td><td>  620</td></tr>\n",
+       "\t<tr><td>2963</td><td>20276</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "A matrix: 2 × 2 of type int\n",
+       "\\begin{tabular}{ll}\n",
+       "\t  258 &   620\\\\\n",
+       "\t 2963 & 20276\\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "A matrix: 2 × 2 of type int\n",
+       "\n",
+       "|  258 |   620 |\n",
+       "| 2963 | 20276 |\n",
+       "\n"
+      ],
+      "text/plain": [
+       "     [,1] [,2] \n",
+       "[1,]  258   620\n",
+       "[2,] 2963 20276"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "a <- n_dge_and_das\n",
     "b <- n_das_but_not_dge\n",
@@ -201,16 +450,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-11-20T10:53:35.435673Z",
+     "iopub.status.busy": "2020-11-20T10:53:35.434348Z",
+     "iopub.status.idle": "2020-11-20T10:53:35.454657Z",
+     "shell.execute_reply": "2020-11-20T10:53:35.453562Z"
+    },
+    "papermill": {
+     "duration": 0.039627,
+     "end_time": "2020-11-20T10:53:35.454811",
+     "exception": false,
+     "start_time": "2020-11-20T10:53:35.415184",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "\tFisher's Exact Test for Count Data\n",
+       "\n",
+       "data:  m\n",
+       "p-value < 2.2e-16\n",
+       "alternative hypothesis: true odds ratio is not equal to 1\n",
+       "95 percent confidence interval:\n",
+       " 2.440286 3.315243\n",
+       "sample estimates:\n",
+       "odds ratio \n",
+       "  2.847428 \n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fisher.test(m)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.017589,
+     "end_time": "2020-11-20T10:53:35.488458",
+     "exception": false,
+     "start_time": "2020-11-20T10:53:35.470869",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "\n"
    ]
@@ -234,7 +527,19 @@
    "mimetype": "text/x-r-source",
    "name": "R",
    "pygments_lexer": "r",
-   "version": "3.6.1"
+   "version": "3.6.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 44.337885,
+   "end_time": "2020-11-20T10:53:36.582749",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "FisherExactTests.ipynb",
+   "output_path": "FisherExactTests.ipynb",
+   "parameters": {},
+   "start_time": "2020-11-20T10:52:52.244864",
+   "version": "2.2.2"
   }
  },
  "nbformat": 4,

--- a/reproduce.sh
+++ b/reproduce.sh
@@ -53,3 +53,4 @@ papermill splicingIndex.ipynb splicingIndex.ipynb
 papermill spliceTypeByChromosome.ipynb spliceTypeByChromosome.ipynb
 papermill altSplicing_events_per_gene.ipynb altSplicing_events_per_gene.ipynb
 papermill tissue_piechart.ipynb tissue_piechart.ipynb
+papermill FisherExactTests.ipynb FisherExactTests.ipynb


### PR DESCRIPTION
This PR updates the `jupyter/FisherExactTests.ipynb` notebook, executing with the data from the ZENODO record [4179559](https://zenodo.org/record/4179559).

To run this notebook programmatically, I executed the commands in the script `reproduce.sh`, which was also updated in the PR here, to include the command for executing `FisherExactTests.ipynb`.

The data are retrieved with `wget` with this method and the conda environment is created with the dependencies for all the notebooks.